### PR TITLE
Improve

### DIFF
--- a/Controllers/indexController.php
+++ b/Controllers/indexController.php
@@ -2,6 +2,6 @@
 
 class FreshExtension_index_Controller extends FreshRSS_index_Controller {
 	public function aboutAction() {
-		Minz_View::prependTitle(_t('ext.about.new_title') . ' · ');
+		Minz_View::prependTitle(_t('ext.hello_world.about.title') . ' · ');
 	}
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
-Extension-HelloWorld
-====================
+# Extension-HelloWorld
 
-An HelloWorld extension
+An HelloWorld extension for [FreshRSS](https://github.com/FreshRSS/FreshRSS).
+
+It is a bit described in the documentation: https://freshrss.github.io/FreshRSS/en/developers/03_Backend/05_Extensions.html#write-an-extension-for-freshrss
+
+## Warning
+
+It is not recommended to install this extension on your production server. This extension manipulates the important “About” page.
+
+## How to install
+
+To install this extension, download the extension archive first and extract it on your PC. Then, upload this on your server. Extensions must be in the `./extensions` directory of your FreshRSS installation.
+
+## What it does
+
+This extension is a little showcase and boilerplate for a FreshRSS extension.
+
+As showcase it will manipulate some little things:
+- the “About” page content will be overwritten
+- the “Save” button titles will be changed
+- the normal view article list will be changed

--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ As showcase it will manipulate some little things:
 - the “About” page content will be overwritten
 - the “Save” button titles will be changed
 - the normal view article list will be changed
+- it loads a CSS and a JavaScript file

--- a/i18n/de/ext.php
+++ b/i18n/de/ext.php
@@ -1,0 +1,21 @@
+<?php
+
+/******************************************************************************/
+/* Each entry of that file can be associated with a comment to indicate its   */
+/* state. When there is no comment, it means the entry is fully translated.   */
+/* The recognized comments are (comment matching is case-insensitive):        */
+/*   + TODO: the entry has never been translated.                             */
+/*   + DIRTY: the entry has been translated but needs to be updated.          */
+/*   + IGNORE: the entry does not need to be translated.                      */
+/* When a comment is not recognized, it is discarded.                         */
+/******************************************************************************/
+
+return array(
+	'hello_world' => array(
+		'no_configuration' => 'Hier kann leider nichts konfiguriert werden!',
+		'about' => array (
+			'title' => 'Über: Hello World FreshRSS',
+			'content' => 'Eine neue „Über“ Seite, die von der Erweiterung „xExtension-HelloWorld“ überschrieben wurde'
+		),
+	),
+);

--- a/i18n/de/gen.php
+++ b/i18n/de/gen.php
@@ -1,0 +1,20 @@
+<?php
+
+/******************************************************************************/
+/* Each entry of that file can be associated with a comment to indicate its   */
+/* state. When there is no comment, it means the entry is fully translated.   */
+/* The recognized comments are (comment matching is case-insensitive):        */
+/*   + TODO: the entry has never been translated.                             */
+/*   + DIRTY: the entry has been translated but needs to be updated.          */
+/*   + IGNORE: the entry does not need to be translated.                      */
+/* When a comment is not recognized, it is discarded.                         */
+/******************************************************************************/
+
+return array(
+	'action' => array(
+		'submit' => 'OK Hello World!',	// IGNORE
+	),
+	'menu' => array(
+		'about' => 'Über FreshRSS und Hello World',
+	),
+);

--- a/i18n/en/ext.php
+++ b/i18n/en/ext.php
@@ -1,7 +1,21 @@
 <?php
 
+/******************************************************************************/
+/* Each entry of that file can be associated with a comment to indicate its   */
+/* state. When there is no comment, it means the entry is fully translated.   */
+/* The recognized comments are (comment matching is case-insensitive):        */
+/*   + TODO: the entry has never been translated.                             */
+/*   + DIRTY: the entry has been translated but needs to be updated.          */
+/*   + IGNORE: the entry does not need to be translated.                      */
+/* When a comment is not recognized, it is discarded.                         */
+/******************************************************************************/
+
 return array(
 	'hello_world' => array(
 		'no_configuration' => 'There is nothing to configure in this extension, sorry!',
+		'about' => array (
+			'title' => 'About: Hello World FreshRSS',
+			'content' => 'A new about page that was overwritten by the extension “xExtension-HelloWorld”'
+		),
 	),
 );

--- a/i18n/en/gen.php
+++ b/i18n/en/gen.php
@@ -1,7 +1,20 @@
 <?php
 
+/******************************************************************************/
+/* Each entry of that file can be associated with a comment to indicate its   */
+/* state. When there is no comment, it means the entry is fully translated.   */
+/* The recognized comments are (comment matching is case-insensitive):        */
+/*   + TODO: the entry has never been translated.                             */
+/*   + DIRTY: the entry has been translated but needs to be updated.          */
+/*   + IGNORE: the entry does not need to be translated.                      */
+/* When a comment is not recognized, it is discarded.                         */
+/******************************************************************************/
+
 return array(
 	'action' => array(
-		'submit' => 'Save',
+		'submit' => 'OK Hello World!',
+	),
+	'menu' => array(
+		'about' => 'About FreshRSS and Hello World',
 	),
 );

--- a/i18n/fr/ext.php
+++ b/i18n/fr/ext.php
@@ -1,7 +1,21 @@
 <?php
 
+/******************************************************************************/
+/* Each entry of that file can be associated with a comment to indicate its   */
+/* state. When there is no comment, it means the entry is fully translated.   */
+/* The recognized comments are (comment matching is case-insensitive):        */
+/*   + TODO: the entry has never been translated.                             */
+/*   + DIRTY: the entry has been translated but needs to be updated.          */
+/*   + IGNORE: the entry does not need to be translated.                      */
+/* When a comment is not recognized, it is discarded.                         */
+/******************************************************************************/
+
 return array(
 	'hello_world' => array(
 		'no_configuration' => 'Il n’y a rien à configurer dans cette extension, désolé !',
+	),
+	'about' => array (
+		'title' => 'About: Hello World FreshRSS',	// TODO
+		'content' => 'A new about page that was overwritten by the extension “xExtension-HelloWorld”'	// TODO
 	),
 );

--- a/i18n/fr/gen.php
+++ b/i18n/fr/gen.php
@@ -1,7 +1,20 @@
 <?php
 
+/******************************************************************************/
+/* Each entry of that file can be associated with a comment to indicate its   */
+/* state. When there is no comment, it means the entry is fully translated.   */
+/* The recognized comments are (comment matching is case-insensitive):        */
+/*   + TODO: the entry has never been translated.                             */
+/*   + DIRTY: the entry has been translated but needs to be updated.          */
+/*   + IGNORE: the entry does not need to be translated.                      */
+/* When a comment is not recognized, it is discarded.                         */
+/******************************************************************************/
+
 return array(
 	'action' => array(
-		'submit' => 'Sauvegarder',
+		'submit' => 'OK Hello World!',	// TODO
+	),
+	'menu' => array(
+		'about' => 'About FreshRSS and Hello World',	// TODO
 	),
 );

--- a/views/index/about.phtml
+++ b/views/index/about.phtml
@@ -1,4 +1,19 @@
-<div class="post content">
-	<h1>About</h1>
-	<p>A new about page!</p>
-</div>
+<?php
+	/** @var FreshRSS_View $this */
+	if (FreshRSS_Auth::hasAccess()) {
+		$this->partial('aside_configure');
+	}
+?>
+
+<main class="post content<?= !FreshRSS_Auth::hasAccess() ? ' centered' : ''?>">
+	<h1><?= _t('ext.hello_world.about.title')?></h1>
+	<p><?= _t('ext.hello_world.about.content')?></p>
+</main>
+
+<?php if (!FreshRSS_Auth::hasAccess()) { ?>
+<footer class="main-footer">
+	<?php if (file_exists(TOS_FILENAME)) { ?>
+		<a href="<?= _url('index', 'tos') ?>"><?= _t('index.tos.title')?></a>
+	<?php } ?>
+</footer>
+<?php } ?>


### PR DESCRIPTION
- fixed missed i18n title of the about page.
- improved the readme.md
- improved the about.phtml: 
  - use i18n strings
  - text explains a bit more
- changed the i18n text, so that the extension results are more visible:
  - `Save` buttons have now another text
  - `about` page menu entry has now another text
- i18n German added
